### PR TITLE
propagate traceback status through ambiguous alignment

### DIFF
--- a/include/abpoa.h
+++ b/include/abpoa.h
@@ -55,6 +55,7 @@ typedef struct {
     int node_s, node_e, query_s, query_e; // for local and  extension mode
     int n_aln_bases, n_matched_bases;
     int32_t best_score; uint8_t is_rc; // is_rc: best_score is from the reverse complement
+    uint8_t traceback_ok;
 } abpoa_res_t;
 
 typedef struct {

--- a/src/abpoa_align.h
+++ b/src/abpoa_align.h
@@ -44,6 +44,7 @@ static inline void abpoa_res_copy(abpoa_res_t *dest, abpoa_res_t *src) {
     dest->query_s = src->query_s, dest->query_e = src->query_e;
     dest->n_aln_bases = src->n_aln_bases, dest->n_matched_bases = src->n_matched_bases;
     dest->best_score = src->best_score, dest->is_rc = src->is_rc;
+    dest->traceback_ok = src->traceback_ok;
 }
 
 static inline abpoa_cigar_t *abpoa_push_cigar(int *n_cigar, int *m_cigar, abpoa_cigar_t *cigar, int op, int len, int32_t node_id, int32_t query_id) {

--- a/src/simd_abpoa_align.c
+++ b/src/simd_abpoa_align.c
@@ -1608,7 +1608,7 @@ int simd_abpoa_align_sequence_to_subgraph(abpoa_t *ab, abpoa_para_t *abpt, int b
     if (abpt->amb_strand) { // ambiguous strand
         // forward strand
         simd_abpoa_align_sequence_to_subgraph1(ab, abpt, beg_node_id, end_node_id, query, qlen, res);
-        if (res->best_score < qlen * abpt->match * .3333) { // TODO .3333
+        if (res->best_score < qlen * abpt->match * .3333 || !res->traceback_ok) { // TODO .3333
             // reverse complement
             int i;
             uint8_t *rc_query = (uint8_t*)_err_malloc(sizeof(uint8_t) * qlen);
@@ -1618,7 +1618,7 @@ int simd_abpoa_align_sequence_to_subgraph(abpoa_t *ab, abpoa_para_t *abpt, int b
             }
             abpoa_res_t rc_res; rc_res.n_cigar = 0, rc_res.graph_cigar = 0, rc_res.is_rc = 1;
             simd_abpoa_align_sequence_to_subgraph1(ab, abpt, beg_node_id, end_node_id, rc_query, qlen, &rc_res);
-            if (rc_res.best_score > res->best_score) abpoa_res_copy(res, &rc_res);
+            if (rc_res.traceback_ok && (rc_res.best_score > res->best_score || !res->traceback_ok)) abpoa_res_copy(res, &rc_res);
             free(rc_query); if (rc_res.n_cigar) free(rc_res.graph_cigar);
         }
     } else simd_abpoa_align_sequence_to_subgraph1(ab, abpt, beg_node_id, end_node_id, query, qlen, res);


### PR DESCRIPTION
This should expose the traceback status to the calling context even when running ambiguous strand alignment.

The decision about which strand to use considers if we have hit the traceback error or not.