### PR TITLE
Use avx2 interface when compiling on ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ CFLAGS      = -Wall -O3 $(EXTRA_FLAGS)
 SIMD_FLAG   = -march=native
 
 ifneq ($(armv7),) # for ARMv7
-	SIMD_FLAG   =  -march=armv7-a -mfpu=neon
+	SIMD_FLAG   =  -march=armv7-a -mfpu=neon -D__AVX2__
 else
 ifneq ($(armv8),) # for ARMv8
 ifneq ($(aarch64),) # for Aarch64 
-	SIMD_FLAG   =  -march=armv8-a+simd
+	SIMD_FLAG   =  -march=armv8-a+simd -D__AVX2__
 else # for Aarch32
-	SIMD_FLAG   =  -march=armv8-a+simd -mfpu=auto
+	SIMD_FLAG   =  -march=armv8-a+simd -mfpu=auto -D__AVX2__
 endif
 endif
 endif

--- a/src/simd_check.c
+++ b/src/simd_check.c
@@ -1,5 +1,26 @@
 #include "simd_instruction.h"
 
+
+//https://stackoverflow.com/questions/152016/detecting-cpu-architecture-compile-time                                                         
+#if MSVC
+#ifdef _M_X86
+#define ARCH_X86
+#endif
+#endif
+
+#if GCC
+#ifdef __i386__
+#define ARCH_X86
+#endif
+#endif
+
+#ifndef ARCH_X86
+
+int simd_check(void) {
+  return SIMD_AVX2;
+}
+#else
+
 #ifndef _MSC_VER
 // adapted from https://github.com/01org/linux-sgx/blob/master/common/inc/internal/linux/cpuid_gnu.h
 void __cpuidex(int cpuid[4], int func_id, int subfunc_id)
@@ -63,4 +84,6 @@ int main(void) {
     fprintf(stderr, "\n");
     return simd_flag;
 }
+#endif
+
 #endif


### PR DESCRIPTION
As discussed in #18, most of the code in simd_check.c is intel specific.  Furthermore, it seems like the interface used in simd_instruction.h, which defaults to sse4.1 (for met at least) doesn't work with clang, making it difficult for users of arm Macs. 

This PR addresses both these issues with hacks that use AVX2 for everything when on arm.   But since this is the AVX2 interface into simde, it should still be portable (on arm it will call the appropriate neon calls).

This builds and runs simple examples on 
* linux / gcc / graviton
* linux / clang / graviton
* mac / clang / m1