### PR TITLE
Stub out github action for python wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,12 +26,9 @@ jobs:
         buildplat:
         - [ubuntu-latest, manylinux_x86_64, auto]
         - [macos-latest, macosx_x86_64, x86_64]
-        - [macos-latest, macosx_arm64, arm64]
+        # skip these for now, need more work
+        #- [macos-latest, macosx_arm64, arm64]
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
-        #exclude:
-        #    # This one fails, I (cjw85) don't care for why
-        #    - buildplat: macosx_arm64
-        #    - python: "cp38"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,6 +28,10 @@ jobs:
         - [macos-latest, macosx_x86_64, x86_64]
         - [macos-latest, macosx_arm64, arm64]
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+        exclude:
+            # This one fails, I (cjw85) don't care for why
+            - buildplat: macosx_arm64
+            - python: "cp38"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,10 +28,10 @@ jobs:
         - [macos-latest, macosx_x86_64, x86_64]
         - [macos-latest, macosx_arm64, arm64]
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
-        exclude:
-            # This one fails, I (cjw85) don't care for why
-            - buildplat: macosx_arm64
-            - python: "cp38"
+        #exclude:
+        #    # This one fails, I (cjw85) don't care for why
+        #    - buildplat: macosx_arm64
+        #    - python: "cp38"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,76 @@
+name: Build and upload to PyPI
+
+# Build on every branch push, tag push, and pull request change:
+on: [push, pull_request]
+# Alternatively, to publish when a (published) GitHub Release is created, use the following:
+# on:
+#   push:
+#   pull_request:
+#   release:
+#     types:
+#       - published
+env:
+  CIBW_BUILD_VERBOSITY: 3
+  #CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+  # Disable building PyPy wheels on all platforms
+  CIBW_SKIP: pp*
+
+jobs:
+  build_wheels:
+    name: Build wheels for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+    runs-on: ${{ matrix.buildplat[0] }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        buildplat:
+        - [ubuntu-latest, manylinux_x86_64, auto]
+        - [macos-latest, macosx_x86_64, x86_64]
+        - [macos-latest, macosx_arm64, arm64]
+        python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.15.0
+        env:
+          CIBW_ARCHS: ${{ matrix.buildplat[2] }}
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+            submodules: 'true'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
@@ -47,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+            submodules: 'true'
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     author_email = "gaoy1@chop.edu",
     license = "MIT",
     keywords = "multiple-sequence-alignment  partial-order-graph-alignment",
-    setup_requires=["cython"],
+    setup_requires=["cython<3"], # see https://github.com/cython/cython/issues/5568
     # Build instructions
     ext_modules = [
         Extension(


### PR DESCRIPTION
I may have done this horribly wrong....

This is an attempt to add github actions to build and push Python wheels to PyPI.

Lines 73-76 require credentials being set up in order to perform the push. See https://github.com/pypa/gh-action-pypi-publish for details.