### PR TITLE
Check input of msa_add

### DIFF
--- a/python/pyabpoa.pyx
+++ b/python/pyabpoa.pyx
@@ -281,6 +281,9 @@ cdef class msa_aligner:
         return self
 
     def msa_add(self, new_seqs):
+        if isinstance(new_seqs, str):
+            raise TypeError('Expected a list of strings. If you want to add a single sequence, pass it as a list: ["ACGT..."]')
+
         cdef int exist_n = 0
         exist_n = self.ab[0].abs[0].n_seq
         if (exist_n == 0):


### PR DESCRIPTION
I think it might be possible that the user wants to add one sequence at a time.

```
seqs = ['AACGAT', 'AAGGAT', 'AAAT', 'TACCAT']

a = pa.msa_aligner(
    aln_mode='l', 
    cons_algrm='mf',
)

_ = a.msa_align(seqs[:2], out_cons=True, out_msa=True)
_ = a.msa_add(seqs[2])
a.msa_output().print_msa()
_ = a.msa_add(seqs[3])
a.msa_output().print_msa()
```

Results in:
```
>Seq_1
---AACGAT
>Seq_2
AAG---GAT
>Seq_3
---A-----
>Seq_4
---A-----
>Seq_5
---A-----
>Seq_6
--------T
>Consensus_sequence
---A----T
>Seq_1
---AACGAT
>Seq_2
AAG---GAT
>Seq_3
---A-----
>Seq_4
---A-----
>Seq_5
---A-----
>Seq_6
--------T
>Seq_7
--------T
>Seq_8
---A-----
>Seq_9
-----C---
>Seq_10
-----C---
>Seq_11
---A-----
>Seq_12
--------T
>Consensus_sequence
---A-----
```

This will run, but here `seqs[2]` and `seqs[3]` are passed directly as a string, and each base is treated as a different sequence. This can be easily fixed by just doing `[seqs[2]]`. Therefore I think the addition of the error message for the user might avoid some unexpected results.

