### PR TITLE
Add batch mode indexing to consensus sequence headers

### DIFF
--- a/src/abpoa.c
+++ b/src/abpoa.c
@@ -150,9 +150,12 @@ int abpoa_main(char *file_fn, int is_list, abpoa_para_t *abpt){
     abpoa_t *ab = abpoa_init();
     if (is_list) { // input file list
         FILE *list_fp = fopen(file_fn, "r"); char read_fn[1024];
+        int batch_index = 1;
         while (fgets(read_fn, sizeof(read_fn), list_fp)) {
             read_fn[strlen(read_fn)-1] = '\0';
+            abpt->batch_index = batch_index;
             abpoa_msa1(ab, abpt, read_fn, stdout);
+            batch_index++;
         }
         fclose(list_fp);
     } else // input file

--- a/src/abpoa.h
+++ b/src/abpoa.h
@@ -83,6 +83,7 @@ typedef struct {
     int align_mode, gap_mode, max_n_cons, cons_algrm; // consensus calling algorithm: 0: partial order graph, 1: majority voting
     double min_freq; // for multiploid data
     int verbose; // to control output msg
+    int batch_index; // index of current file in batch mode (for output header)
 
     // char LogTable65536[65536];
     // char bit_table16[65536];

--- a/src/abpoa_align.c
+++ b/src/abpoa_align.c
@@ -149,6 +149,7 @@ abpoa_para_t *abpoa_init_para(void) {
     abpt->progressive_poa = 0; // progressive partial order alignment
 
     abpt->verbose = ABPOA_NONE_VERBOSE;
+    abpt->batch_index = 0; // 0 means not in batch mode
 
     // abpt->simd_flag = simd_check();
 

--- a/src/abpoa_output.c
+++ b/src/abpoa_output.c
@@ -579,6 +579,9 @@ void abpoa_output_fx_consensus(abpoa_t *ab, abpoa_para_t *abpt, FILE *out_fp) {
     for (cons_i = 0; cons_i < abc->n_cons; ++cons_i) {
         if (abpt->out_fq) fprintf(out_fp, "@Consensus_sequence");
         else fprintf(out_fp, ">Consensus_sequence");
+        if (abpt->batch_index > 0) {
+            fprintf(out_fp, "_%d", abpt->batch_index); // batch index for file mapping
+        }
         if (abc->n_cons > 1) {
             fprintf(out_fp, "_%d ", cons_i+1); // cons_id
             for (j = 0; j < abc->clu_n_seq[cons_i]; ++j) { // cluter read_id
@@ -592,6 +595,9 @@ void abpoa_output_fx_consensus(abpoa_t *ab, abpoa_para_t *abpt, FILE *out_fp) {
         } fprintf(out_fp, "\n");
         if (abpt->out_fq) {
             fprintf(out_fp, "+Consensus_sequence");
+            if (abpt->batch_index > 0) {
+                fprintf(out_fp, "_%d", abpt->batch_index); // batch index for file mapping
+            }
             if (abc->n_cons > 1) {
                 fprintf(out_fp, "_%d ", cons_i+1); // cons_id
                 for (j = 0; j < abc->clu_n_seq[cons_i]; ++j) { // cluter read_id


### PR DESCRIPTION
## Problem
When using batch mode (`-l` flag), failed consensus generation causes input-output mapping issues in
downstream tools. If some input files fail to produce consensus sequences, the remaining consensus sequences
lose their association with the original input files, which might contain information that a user would want to propagate.

## Solution
Add file index to consensus sequence headers (e.g., `>Consensus_sequence_1`, `>Consensus_sequence_2`) to
enable proper mapping between input files and output sequences. Failed consensus sequence generation results in a skipped index value.

## Changes
- Add `batch_index` field to `abpoa_para_t` structure
- Track file index during batch processing loop
- Include index in FASTA/FASTQ headers when `batch_index > 0`
- Uses 1-based indexing for user-friendly output

## Testing
Tested with batch files containing both successful and failed consensus generation:
- Failed files produce no output (as expected)
- Successful files produce headers with correct indices
- Non-batch mode remains unchanged

## Backward Compatibility
- Non-batch mode output unchanged
- Existing tools can ignore the index suffix
- No breaking changes to API or command line interface

Note: I used an AI code assistant to make these changes. I don't know C but I reviewed all the changes and they are minimal, seem correct, and were validated with some small tests.

I also could just be missing some way to use batch mode that makes this modification unnecessary. If that's the case, please let me know. Thanks!