### PR TITLE
feat: adding pyproject.toml to enable building via newer python versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ $(SRC_DIR)/abpoa_dispatch_simd_avx512bw.o:$(SRC_DIR)/abpoa_dispatch_simd.c $(SRC
 	$(CC) -c $(CFLAGS) -DABPOA_SIMD_DISPATCH -mavx512bw -I$(INC_DIR) $< -o $@
 
 install_py: setup.py python/cabpoa.pxd python/pyabpoa.pyx python/README.md
-	${py_SIMD_FLAG} python setup.py install
+	${py_SIMD_FLAG} python -m pip install .
 	
 sdist: setup.py python/cabpoa.pxd python/pyabpoa.pyx python/README.md
 	${py_SIMD_FLAG} python setup.py sdist #bdist_wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = [
+    "setuptools",
+    "cython"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyabpoa"
+version = "1.5.6"
+urls = {Project-URL = "https://github.com/yangao07/abPOA"}
+authors = [{name = "Yan Gao", email = "yangao@ds.dfci.harvard.edu"}]
+license = "MIT"
+keywords = ["multiple-sequence-alignment", "partial-order-graph-alignment"]
+description = "pyabpoa: SIMD-based partial order alignment using adaptive band"
+readme = "python/README.md"

--- a/setup.py
+++ b/setup.py
@@ -58,16 +58,8 @@ long_description = open('python/README.md').read()
 
 setup(
     # Information
-    name = "pyabpoa",
-    description = "pyabpoa: SIMD-based partial order alignment using adaptive band",
     long_description = long_description,
     long_description_content_type="text/markdown",
-    version = "1.5.5",
-    url = "https://github.com/yangao07/abPOA",
-    author = "Yan Gao",
-    author_email = "yangao@ds.dfci.harvard.edu",
-    license = "MIT",
-    keywords = "multiple-sequence-alignment  partial-order-graph-alignment",
     setup_requires=["cython"],
     # Build instructions
     ext_modules = [


### PR DESCRIPTION
Hello! This PR would add a pyproject.toml file to the repo, enabling building via modern python build standards / peps which should clear up some of the issues with installing via newer setuptools versions. (See https://github.com/pypa/setuptools/issues/5174 ).

