### PR TITLE
feat: support quality scores in python api

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -76,9 +76,9 @@ This constructs a multiple sequence alignment handler of pyabpoa, it accepts the
 * **extra_f**: second adaptive banding paremete; the number of extra bases added on both sites of the band is *b+f\*L*, where *L* is the length of the aligned sequence; default : **0.01**
 * **cons_algrm**: consensus calling algorithm. 'HB': heaviest bunlding, 'MF': most frequent bases; default: **'HB'**
 
-The `msa_aligner` handler provides one method `msa` which performs multiple sequence alignment and takes four arguments:
+The `msa_aligner` handler provides one method `msa` which performs multiple sequence alignment and accepts the following arguments:
 ```
-pyabpoa.msa_aligner.msa(seqs, out_cons, out_msa, out_pog='', incr_fn='')
+pyabpoa.msa_aligner.msa(seqs, out_cons, out_msa, out_pog='', incr_fn='', qscores=None)
 ```
 
 * **seqs**: a list variable containing a set of input sequences; **positional**
@@ -88,12 +88,15 @@ pyabpoa.msa_aligner.msa(seqs, out_cons, out_msa, out_pog='', incr_fn='')
 * **min_freq**: minimum frequency of each consensus to output (effective when **max_n_cons** > 1); default: **0.3**
 * **out_pog**: name of a file (`.png` or `.pdf`) to store the plot of the final alignment graph; default: **''**
 * **incr_fn**: name of an existing graph (GFA) or MSA (FASTA) file, incrementally align sequence to this graph/MSA; default: **''**
+* **qscores**: optional per-sequence quality information used to weight the consensus graph. Each entry must match the corresponding sequence length and should be a list of integer Phred scores, e.g. `record.letter_annotations["phred_quality"]` from Biopython; default: **None**
+
+When `qscores` is provided, pyabpoa enables quality-weighted consensus (`use_qv`) for that run. This is effective for heaviest-bundling consensus (`cons_algrm='HB'`), matching the CLI `-Q/--use-qual-weight` behavior.
 
 `msa_aligner` also provides three methods for incrementally adding sequences to graph/MSA:
 
 ```
-pyabpoa.msa_aligner.msa_align(seqs, out_cons, out_msa, max_n_cons=1, min_freq=0.25, incr_fn=b'')
-pyabpoa.msa_aligner.msa_add(new_seqs)
+pyabpoa.msa_aligner.msa_align(seqs, out_cons, out_msa, max_n_cons=1, min_freq=0.25, incr_fn=b'', qscores=None)
+pyabpoa.msa_aligner.msa_add(new_seqs, qscores=None)
 pyabpoa.msa_aligner.msa_output()
 ```
 
@@ -113,6 +116,7 @@ This class describes the information of the generated consensus sequence and the
 * **cons_len**: an array of consensus sequence length(s)
 * **cons_seq**: an array of consensus sequence(s)
 * **cons_cov**: an array of consensus sequence coverage for each base
+* **cons_qv**: an array of consensus quality strings in FASTQ encoding
 * **msa_len**: size of each row in the RC-MSA
 * **msa_seq**: an array containing `n_seq`+`n_cons` strings that demonstrates the RC-MSA, each consisting of one input sequence and several `-` indicating the alignment gaps. 
 

--- a/python/example.py
+++ b/python/example.py
@@ -1,6 +1,6 @@
 import pyabpoa as pa
 
-#@parameters of msa_aligner:
+# @parameters of msa_aligner:
 #   aln_mode='g' # g: global, l: local, e: extension
 #   is_aa=False # set as True if input is amino acid sequence
 #   score_matrix='' # file of score matrix, e.g. HOXD70.mtx/BLOSUM62.mtx
@@ -20,71 +20,95 @@ a = pa.msa_aligner()
 
 print("==== First exmaple: 2 consensus sequences ====\n")
 # for multiple consensus
-seqs=[
- 'CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT',
- 'CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT'
- ]
+seqs = [
+    "CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATAAAAAAAAAAAAAAAAAAACGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+    "CGATCGATCGATCGATGCATGCATCGATGCATCGATCGATGCATGCAT",
+]
 
-#@parameters of msa
-#seqs: multiple sequences
-out_cons=True # generate consensus sequence, set as False to disable
-out_msa=True # generate row-column multiple sequence alignment, set as False to disable
-#out_pog="example1.png" # generate plot of alignment graph, set None to disable, require `dot` to be installed
+# @parameters of msa
+# seqs: multiple sequences
+out_cons = True  # generate consensus sequence, set as False to disable
+out_msa = True   # generate row-column multiple sequence alignment, set as False to disable
+# out_pog="example1.png" # generate plot of alignment graph, set None to disable, require `dot` to be installed
 max_n_cons = 2
 
 # multiple sequence alignment for 'seqs'
-res=a.msa(seqs, out_cons=out_cons, out_msa=out_msa, max_n_cons=max_n_cons) #, out_pog=out_pog)
+res = a.msa(seqs, out_cons=out_cons, out_msa=out_msa, max_n_cons=max_n_cons)  # , out_pog=out_pog)
 
 # output result
 if out_cons:
     for i in range(res.n_cons):
-        print(">Consensus_sequence_{}".format(i+1))
+        print(f">Consensus_sequence_{i + 1}")
         print(res.cons_seq[i])
 if out_msa:
     res.print_msa()
 
 
 print("\n\n==== Second exmaple: 1 consensus sequence ====\n")
-seqs=[
-'CGTCAATCTATCGAAGCATACGCGGGCAGAGCCGAAGACCTCGGCAATCCA',
-'CCACGTCAATCTATCGAAGCATACGCGGCAGCCGAACTCGACCTCGGCAATCAC',
-'CGTCAATCTATCGAAGCATACGCGGCAGAGCCCGGAAGACCTCGGCAATCAC',
-'CGTCAATGCTAGTCGAAGCAGCTGCGGCAGAGCCGAAGACCTCGGCAATCAC',
-'CGTCAATCTATCGAAGCATTCTACGCGGCAGAGCCGACCTCGGCAATCAC',
-'CGTCAATCTAGAAGCATACGCGGCAAGAGCCGAAGACCTCGGCCAATCAC',
-'CGTCAATCTATCGGTAAAGCATACGCTCTGTAGCCGAAGACCTCGGCAATCAC',
-'CGTCAATCTATCTTCAAGCATACGCGGCAGAGCCGAAGACCTCGGCAATC',
-'CGTCAATGGATCGAGTACGCGGCAGAGCCGAAGACCTCGGCAATCAC',
-'CGTCAATCTAATCGAAGCATACGCGGCAGAGCCGTCTACCTCGGCAATCACGT'
+seqs = [
+    "CGTCAATCTATCGAAGCATACGCGGGCAGAGCCGAAGACCTCGGCAATCCA",
+    "CCACGTCAATCTATCGAAGCATACGCGGCAGCCGAACTCGACCTCGGCAATCAC",
+    "CGTCAATCTATCGAAGCATACGCGGCAGAGCCCGGAAGACCTCGGCAATCAC",
+    "CGTCAATGCTAGTCGAAGCAGCTGCGGCAGAGCCGAAGACCTCGGCAATCAC",
+    "CGTCAATCTATCGAAGCATTCTACGCGGCAGAGCCGACCTCGGCAATCAC",
+    "CGTCAATCTAGAAGCATACGCGGCAAGAGCCGAAGACCTCGGCCAATCAC",
+    "CGTCAATCTATCGGTAAAGCATACGCTCTGTAGCCGAAGACCTCGGCAATCAC",
+    "CGTCAATCTATCTTCAAGCATACGCGGCAGAGCCGAAGACCTCGGCAATC",
+    "CGTCAATGGATCGAGTACGCGGCAGAGCCGAAGACCTCGGCAATCAC",
+    "CGTCAATCTAATCGAAGCATACGCGGCAGAGCCGTCTACCTCGGCAATCACGT",
 ]
 
-#@parameters of msa
-#seqs: multiple sequences
-out_cons=True # generate consensus sequence, set as False to disable
-out_msa=True # generate row-column multiple sequence alignment, set as False to disable
+# @parameters of msa
+# seqs: multiple sequences
+out_cons = True  # generate consensus sequence, set as False to disable
+out_msa = True  # generate row-column multiple sequence alignment, set as False to disable
 # out_pog="example2.png" # generate plot of alignment graph, set None to disable
 max_n_cons = 1
 
 # multiple sequence alignment for 'seqs'
-res=a.msa(seqs, out_cons=out_cons, out_msa=out_msa, max_n_cons=max_n_cons) #, out_pog=out_pog)
+res = a.msa(seqs, out_cons=out_cons, out_msa=out_msa, max_n_cons=max_n_cons)  # , out_pog=out_pog)
 
 # output result
 if out_cons:
     for i in range(res.n_cons):
-        print(">Consensus_sequence_{}".format(i+1))
+        print(f">Consensus_sequence_{i + 1}")
         print(res.cons_seq[i])
 if out_msa:
     for i in range(res.n_seq):
-        print(">Seq_{}".format(i+1))
+        print(f">Seq_{i + 1}")
         print(res.msa_seq[i])
     for i in range(res.n_cons):
-        print(">Consensus_sequence_{}".format(i+1))
-        print(res.msa_seq[res.n_seq+i])
+        print(f">Consensus_sequence_{i + 1}")
+        print(res.msa_seq[res.n_seq + i])
+
+
+print("\n\n==== Third exmaple: quality-weighted consensus ====\n")
+seqs = [
+    "ACGT",
+    "ACGT",
+    "ACGA",
+]
+
+# Per-base Phred qualities. This matches the shape returned by
+# Biopython's record.letter_annotations["phred_quality"] for FASTQ input.
+qscores = [
+    [40, 40, 40, 40],
+    [35, 35, 35, 35],
+    [30, 30, 30, 5],
+]
+
+res = a.msa(seqs, out_cons=True, out_msa=False, qscores=qscores)
+
+for i in range(res.n_cons):
+    print(f"@Consensus_sequence_{i + 1}")
+    print(res.cons_seq[i])
+    print("+")
+    print(res.cons_qv[i])

--- a/python/pyabpoa.pyx
+++ b/python/pyabpoa.pyx
@@ -10,11 +10,11 @@ from libc.string cimport strcpy
 cdef class msa_result:
     cdef int n_seq
     cdef int n_cons
-    cdef clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov  # _cons_len:[int], _cons_seq:['']
+    cdef clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, cons_qv  # _cons_len:[int], _cons_seq:['']
     cdef int msa_len
     cdef msa_seq  # _msa_seq:['']
 
-    def __cinit__(self, n_seq, n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, msa_len, msa_seq):
+    def __cinit__(self, n_seq, n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, cons_qv, msa_len, msa_seq):
         self.n_seq = n_seq
         self.n_cons = n_cons
         self.clu_n_seq = clu_n_seq
@@ -22,6 +22,7 @@ cdef class msa_result:
         self.cons_len = cons_len
         self.cons_seq = cons_seq
         self.cons_cov = cons_cov
+        self.cons_qv = cons_qv
         self.msa_len = msa_len
         self.msa_seq = msa_seq
 
@@ -47,6 +48,9 @@ cdef class msa_result:
     def cons_cov(self): return self.cons_cov
 
     @property
+    def cons_qv(self): return self.cons_qv
+
+    @property
     def msa_len(self): return self.msa_len
 
     @property
@@ -56,13 +60,13 @@ cdef class msa_result:
         if not self.msa_seq: return
         for i, s in enumerate(self.msa_seq):
             if i < self.n_seq:
-                print('>Seq_{}'.format(i+1))
+                print(f'>Seq_{i+1}')
             else:
                 if self.n_cons > 1:
-                    cons_id = '_{} {}'.format(i-self.n_seq+1, ','.join(list(map(str, self.clu_read_ids[i-self.n_seq]))))
+                    cons_id = f'_{i-self.n_seq+1} {",".join(list(map(str, self.clu_read_ids[i-self.n_seq])))}'
                 else:
                     cons_id = ''
-                print('>Consensus_sequence{}'.format(cons_id))
+                print(f'>Consensus_sequence{cons_id}')
             print(s)
         return
 
@@ -75,7 +79,7 @@ def set_seq_int_dict(m):
         seqs = 'ACGTNBDEFHIJKLMOPQRSUVWXYZ*'
         ints = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
     else:
-        raise Exception('Unexpected m: {}'.format(m))
+        raise Exception(f'Unexpected m: {m}')
 
     seq2int_dict = dd(lambda: m-1)
     int2seq_dict = dd(lambda: '-')
@@ -106,7 +110,7 @@ cdef class msa_aligner:
         elif aln_mode == 'e':
             self.abpt.align_mode = ABPOA_EXTEND_MODE
         else:
-            raise Exception('Unknown align mode: {}'.format(aln_mode))
+            raise Exception(f'Unknown align mode: {aln_mode}')
         if is_aa:
             self.abpt.m = 27
             self.abpt.mat = <int*>malloc(27 * 27 * cython.sizeof(int))
@@ -141,7 +145,7 @@ cdef class msa_aligner:
         elif cons_algrm.upper() == 'HB':
             self.abpt.cons_algrm = ABPOA_HB
         else:
-            raise Exception('Unknown conseneus calling mode: {}'.format(cons_algrm))
+            raise Exception(f'Unknown conseneus calling mode: {cons_algrm}')
 
         self.seq2int_dict, self.int2seq_dict = set_seq_int_dict(self.abpt.m)
 
@@ -152,13 +156,62 @@ cdef class msa_aligner:
     def __bool__(self):
         return self.ab != NULL
 
+    cdef int* _prepare_weights(self, seq, qscore):
+        cdef Py_ssize_t i, seq_l = len(seq)
+        cdef int *weights = NULL
 
-    def msa(self, seqs, out_cons, out_msa, max_n_cons=1, min_freq=0.25, out_pog=b'', incr_fn=b''):
+        weights = <int*>malloc(seq_l * cython.sizeof(int))
+        if weights == NULL:
+            raise MemoryError()
+
+        try:
+            if len(qscore) != seq_l:
+                raise ValueError('Each qscore array must have the same length as its sequence.')
+            for i in range(seq_l):
+                weights[i] = int(qscore[i])
+                if weights[i] < 0:
+                    raise ValueError('Qscores must be non-negative integers.')
+        except:
+            free(weights)
+            raise
+        return weights
+
+    cdef void _add_sequences(self, seqs, qscores, int exist_n, int tot_n):
+        cdef uint8_t *bseq
+        cdef int *weights = NULL
+        cdef int seq_l
+        cdef Py_ssize_t i
+        cdef abpoa_res_t res
+
+        if qscores is not None and len(qscores) != len(seqs):
+            raise ValueError('qscores must contain one entry per input sequence.')
+
+        for read_i, seq in enumerate(seqs):
+            seq_l = len(seq)
+            bseq = <uint8_t*>malloc(seq_l * cython.sizeof(uint8_t))
+            if bseq == NULL:
+                raise MemoryError()
+            weights = NULL
+            res.n_cigar = 0
+            res.graph_cigar = NULL
+            try:
+                for i in range(seq_l):
+                    bseq[i] = self.seq2int_dict[seq[i]]
+                if qscores is not None:
+                    weights = self._prepare_weights(seq, qscores[read_i])
+                abpoa_align_sequence_to_graph(self.ab, &self.abpt, bseq, seq_l, &res)
+                abpoa_add_graph_alignment(self.ab, &self.abpt, bseq, weights, seq_l, NULL, res, exist_n+read_i, tot_n, 1)
+            finally:
+                free(bseq)
+                if weights != NULL:
+                    free(weights)
+                if res.n_cigar:
+                    free(res.graph_cigar)
+
+    def msa(self, seqs, out_cons, out_msa, max_n_cons=1, min_freq=0.25, out_pog=b'', incr_fn=b'', qscores=None):
         cdef int seq_n = len(seqs)
         cdef int exist_n = 0
         cdef int tot_n = seq_n
-        cdef uint8_t *bseq
-        cdef abpoa_res_t res
         cdef abpoa_cons_t abc
 
         if out_cons: self.abpt.out_cons = 1
@@ -169,6 +222,7 @@ cdef class msa_aligner:
             raise Exception('Error: max number of consensus sequences should be 1 or 2.')
         self.abpt.max_n_cons = max_n_cons
         self.abpt.min_freq = min_freq
+        self.abpt.use_qv = 1 if qscores is not None else 0
         if out_pog: 
             if isinstance(out_pog, str): out_pog = bytes(out_pog, 'utf-8')
             self.abpt.out_pog = out_pog
@@ -187,18 +241,7 @@ cdef class msa_aligner:
             self.abpt.incr_fn = NULL
 
         self.ab[0].abs[0].n_seq += seq_n
-
-        for read_i, seq in enumerate(seqs):
-            seq_l = len(seq)
-            bseq = <uint8_t*>malloc(seq_l * cython.sizeof(uint8_t))
-            for i in range(seq_l):
-                bseq[i] = self.seq2int_dict[seq[i]]
-            res.n_cigar = 0
-            abpoa_align_sequence_to_graph(self.ab, &self.abpt, bseq, seq_l, &res)
-
-            abpoa_add_graph_alignment(self.ab, &self.abpt, bseq, NULL, seq_l, NULL, res, exist_n+read_i, tot_n, 1)
-            free(bseq)
-            if res.n_cigar: free(res.graph_cigar)
+        self._add_sequences(seqs, qscores, exist_n, tot_n)
 
         if self.abpt.out_msa:
             abpoa_generate_rc_msa(self.ab, &self.abpt)
@@ -206,12 +249,12 @@ cdef class msa_aligner:
             abpoa_generate_consensus(self.ab, &self.abpt)
         abc = self.ab[0].abc[0]
 
-        n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, msa_len, msa_seq = 0, [], [], [], [], [], 0, []
+        n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, cons_qv, msa_len, msa_seq = 0, [], [], [], [], [], [], 0, []
         n_cons = abc.n_cons
         for i in range(n_cons):
             clu_n_seq.append(abc.clu_n_seq[i])
             cons_len.append(abc.cons_len[i])
-            clu_read_ids1, cons_seq1, cons_cov1 = [], '', []
+            clu_read_ids1, cons_seq1, cons_cov1, cons_qv1 = [], '', [], ''
             for j in range(abc.clu_n_seq[i]):
                 clu_read_ids1.append(abc.clu_read_ids[i][j])
             clu_read_ids.append(clu_read_ids1)
@@ -220,8 +263,11 @@ cdef class msa_aligner:
                 if isinstance(c, bytes): c = ord(c)
                 cons_seq1 += self.int2seq_dict[c]
                 cons_cov1.append(abc.cons_cov[i][j])
+                if abc.cons_phred_score != NULL:
+                    cons_qv1 += chr(abc.cons_phred_score[i][j])
             cons_seq.append(cons_seq1)
             cons_cov.append(cons_cov1)
+            cons_qv.append(cons_qv1)
 
         msa_len = abc.msa_len
         if msa_len > 0:
@@ -234,15 +280,12 @@ cdef class msa_aligner:
 
         if self.abpt.out_pog:
             abpoa_dump_pog(self.ab, &self.abpt)
-        return msa_result(tot_n, n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, msa_len, msa_seq)
+        return msa_result(tot_n, n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, cons_qv, msa_len, msa_seq)
 
-    def msa_align(self, seqs, out_cons, out_msa, max_n_cons=1, min_freq=0.25, incr_fn=b''):
+    def msa_align(self, seqs, out_cons, out_msa, max_n_cons=1, min_freq=0.25, incr_fn=b'', qscores=None):
         cdef int seq_n = len(seqs)
         cdef int exist_n = 0
         cdef int tot_n = seq_n
-        cdef uint8_t *bseq
-        cdef abpoa_res_t res
-        cdef abpoa_cons_t abc
 
         if out_cons: self.abpt.out_cons = 1
         else: self.abpt.out_cons = 0
@@ -252,6 +295,7 @@ cdef class msa_aligner:
             raise Exception('Error: max number of consensus sequences should be 1 or 2.')
         self.abpt.max_n_cons = max_n_cons
         self.abpt.min_freq = min_freq
+        self.abpt.use_qv = 1 if qscores is not None else 0
 
         abpoa_post_set_para(&self.abpt)
         abpoa_reset(self.ab, &self.abpt, len(seqs[0]))
@@ -266,21 +310,10 @@ cdef class msa_aligner:
             self.abpt.incr_fn = NULL
 
         self.ab[0].abs[0].n_seq += seq_n
-
-        for read_i, seq in enumerate(seqs):
-            seq_l = len(seq)
-            bseq = <uint8_t*>malloc(seq_l * cython.sizeof(uint8_t))
-            for i in range(seq_l):
-                bseq[i] = self.seq2int_dict[seq[i]]
-            res.n_cigar = 0
-            abpoa_align_sequence_to_graph(self.ab, &self.abpt, bseq, seq_l, &res)
-
-            abpoa_add_graph_alignment(self.ab, &self.abpt, bseq, NULL, seq_l, NULL, res, exist_n+read_i, tot_n, 1)
-            free(bseq)
-            if res.n_cigar: free(res.graph_cigar)
+        self._add_sequences(seqs, qscores, exist_n, tot_n)
         return self
 
-    def msa_add(self, new_seqs):
+    def msa_add(self, new_seqs, qscores=None):
         if isinstance(new_seqs, str):
             raise TypeError('Expected a list of strings. If you want to add a single sequence, pass it as a list: ["ACGT..."]')
 
@@ -290,27 +323,16 @@ cdef class msa_aligner:
             raise Exception('Error: no existing sequences in the graph. Please run msa() or msa_align() first.')
         cdef int seq_n = len(new_seqs)
         cdef int tot_n = seq_n
-        cdef uint8_t *bseq
-        cdef abpoa_res_t res
-        cdef abpoa_cons_t abc
 
         tot_n += exist_n
         self.ab[0].abs[0].n_seq += seq_n
-
-        for read_i, seq in enumerate(new_seqs):
-            seq_l = len(seq)
-            bseq = <uint8_t*>malloc(seq_l * cython.sizeof(uint8_t))
-            for i in range(seq_l):
-                bseq[i] = self.seq2int_dict[seq[i]]
-            res.n_cigar = 0
-            abpoa_align_sequence_to_graph(self.ab, &self.abpt, bseq, seq_l, &res)
-
-            abpoa_add_graph_alignment(self.ab, &self.abpt, bseq, NULL, seq_l, NULL, res, exist_n+read_i, tot_n, 1)
-            free(bseq)
-            if res.n_cigar: free(res.graph_cigar)
+        if qscores is not None:
+            self.abpt.use_qv = 1
+        self._add_sequences(new_seqs, qscores, exist_n, tot_n)
         return self
 
     def msa_output(self):
+        cdef abpoa_cons_t abc
         if self.abpt.out_msa:
             abpoa_generate_rc_msa(self.ab, &self.abpt)
         elif self.abpt.out_cons:
@@ -318,12 +340,12 @@ cdef class msa_aligner:
         seq_n = self.ab[0].abs[0].n_seq
         abc = self.ab[0].abc[0]
 
-        n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, msa_len, msa_seq = 0, [], [], [], [], [], 0, []
+        n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, cons_qv, msa_len, msa_seq = 0, [], [], [], [], [], [], 0, []
         n_cons = abc.n_cons
         for i in range(n_cons):
             clu_n_seq.append(abc.clu_n_seq[i])
             cons_len.append(abc.cons_len[i])
-            clu_read_ids1, cons_seq1, cons_cov1 = [], '', []
+            clu_read_ids1, cons_seq1, cons_cov1, cons_qv1 = [], '', [], ''
             for j in range(abc.clu_n_seq[i]):
                 clu_read_ids1.append(abc.clu_read_ids[i][j])
             clu_read_ids.append(clu_read_ids1)
@@ -332,8 +354,11 @@ cdef class msa_aligner:
                 if isinstance(c, bytes): c = ord(c)
                 cons_seq1 += self.int2seq_dict[c]
                 cons_cov1.append(abc.cons_cov[i][j])
+                if abc.cons_phred_score != NULL:
+                    cons_qv1 += chr(abc.cons_phred_score[i][j])
             cons_seq.append(cons_seq1)
             cons_cov.append(cons_cov1)
+            cons_qv.append(cons_qv1)
 
         msa_len = abc.msa_len
         if msa_len > 0:
@@ -343,5 +368,4 @@ cdef class msa_aligner:
                     if isinstance(c, bytes): c = ord(c)
                     msa_seq1 += self.int2seq_dict[c]
                 msa_seq.append(msa_seq1)
-        return msa_result(seq_n, n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, msa_len, msa_seq)
-
+        return msa_result(seq_n, n_cons, clu_n_seq, clu_read_ids, cons_len, cons_seq, cons_cov, cons_qv, msa_len, msa_seq)


### PR DESCRIPTION
Hi @yangao07,

This PR implements the support of Q-scores as weights when using the Python API.
The new `qscores` parameter is optional and excepts a list of lists of integers (Phred scores).
This also exposes the quality of the consensus by the attribute `cons_qv`.

I added a new example and updated the README of the Python API.
I also took the liberty of formatting the Python example and converting `.format()` to f-strings. I you don't like this I can revert it to follow the original style.

Closes #54.