### PR TITLE
Add explicit RISC-V portable build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,10 +172,13 @@ elseif(_ABPOA_WASM)
     target_compile_options(abpoa PRIVATE -msimd128)
 
 elseif(_ABPOA_RISCV)
-    # RISC-V: use the existing SIMDE-backed portable SIMD path without
-    # injecting host-specific march flags or x86 dispatch machinery.
+    # RISC-V: like ARM, use the existing SIMDE-backed AVX2-flavored path
+    # without injecting host-specific march flags or x86 dispatch machinery.
+    # Leaving __AVX2__ undefined falls back to the 128-bit SSE2-style path,
+    # which is not the project's validated portable configuration.
     message(STATUS "RISC-V target detected; building abPOA with the portable SIMDE path")
     target_sources(abpoa PRIVATE src/abpoa_align_simd.c)
+    target_compile_definitions(abpoa PRIVATE __AVX2__)
 
 else()
     # Fallback: single compile with -march=native

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
     set(_ABPOA_AARCH64 TRUE)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^armv7")
     set(_ABPOA_ARM32 TRUE)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64|riscv32|riscv)")
+    set(_ABPOA_RISCV TRUE)
 endif()
 
 if(_ABPOA_X86_64)
@@ -168,6 +170,12 @@ elseif(_ABPOA_WASM)
     # (USE_SIMDE and SIMDE_ENABLE_NATIVE_ALIASES set on base target above)
     target_sources(abpoa PRIVATE src/abpoa_align_simd.c)
     target_compile_options(abpoa PRIVATE -msimd128)
+
+elseif(_ABPOA_RISCV)
+    # RISC-V: use the existing SIMDE-backed portable SIMD path without
+    # injecting host-specific march flags or x86 dispatch machinery.
+    message(STATUS "RISC-V target detected; building abPOA with the portable SIMDE path")
+    target_sources(abpoa PRIVATE src/abpoa_align_simd.c)
 
 else()
     # Fallback: single compile with -march=native

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 endif
 
 ifneq ($(filter riscv%,$(ARCH)),)
-	SIMD_FLAG =
+	SIMD_FLAG = -D__AVX2__
 	OBJS = ${BASIC_OBJS} $(addprefix $(SRC_DIR)/, abpoa_align_simd.o)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,11 @@ else
 endif
 endif
 
+ifneq ($(filter riscv%,$(ARCH)),)
+	SIMD_FLAG =
+	OBJS = ${BASIC_OBJS} $(addprefix $(SRC_DIR)/, abpoa_align_simd.o)
+endif
+
 # override if user specified
 ifneq ($(armv7),) # for ARMv7
 	SIMD_FLAG   =  -march=armv7-a -mfpu=neon -D__AVX2__

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ significant speed improvement over existing tools.
 abPOA supports three alignment modes (global, local, extension) and flexible scoring schemes that allow linear, affine and convex gap penalties. 
 It right now supports SSE2/SSE4.1/AVX2 vectorization.
 For `riscv64`, the current portability path uses the existing SIMDE-backed
-generic build rather than x86 runtime dispatch or a dedicated RVV backend.
+AVX2-style generic build rather than x86 runtime dispatch or a dedicated RVV
+backend.
 
 For more information, please refer to our [paper](https://dx.doi.org/10.1093/bioinformatics/btaa963) published in Bioinformatics.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ significant speed improvement over existing tools.
 
 abPOA supports three alignment modes (global, local, extension) and flexible scoring schemes that allow linear, affine and convex gap penalties. 
 It right now supports SSE2/SSE4.1/AVX2 vectorization.
+For `riscv64`, the current portability path uses the existing SIMDE-backed
+generic build rather than x86 runtime dispatch or a dedicated RVV backend.
 
 For more information, please refer to our [paper](https://dx.doi.org/10.1093/bioinformatics/btaa963) published in Bioinformatics.
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ else:
     elif machine_arch in ["aarch32"]:
         simd_flag = ['-march=armv8-a+simd', '-mfpu=auto -D__AVX2__']
     elif machine_arch.startswith("riscv"):
-        simd_flag = []
+        simd_flag = ['-D__AVX2__']
     else: # x86_64
         simd_flag=['-march=native']
         if os.getenv('SSE4', False):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ else:
         simd_flag = ['-march=armv8-a+simd', '-D__AVX2__']
     elif machine_arch in ["aarch32"]:
         simd_flag = ['-march=armv8-a+simd', '-mfpu=auto -D__AVX2__']
+    elif machine_arch.startswith("riscv"):
+        simd_flag = []
     else: # x86_64
         simd_flag=['-march=native']
         if os.getenv('SSE4', False):


### PR DESCRIPTION
## Why

`abPOA` already contains a portable `SIMDE`-based path for non-dispatch builds, but the build entry points still treated unknown architectures as “fallback to `-march=native`”. For `riscv64`, that leaves the project in an ambiguous state:

- CMake does not recognize RISC-V as a known target class and falls through to a host-tuned fallback branch.
- the Makefile keeps `SIMD_FLAG=-march=native` for unknown architectures.
- `setup.py` also defaults non-ARM/non-x86 builds to `-march=native`.

This patch makes the existing portable path explicit for RISC-V without changing the core alignment algorithm or claiming RVV support.

During verification, one additional RISC-V-specific issue showed up: leaving `__AVX2__` undefined forces `abPOA` onto the 128-bit SSE2-style `SIMDE` path, and that path fails in `cg_backtrack` on the real sample workload. The project's already-supported non-x86 portable configuration is the AVX2-style `SIMDE` path, which is also what the ARM build already selects explicitly. This patch therefore keeps RISC-V on the same portable AVX2-style `SIMDE` interface instead of the narrower SSE2-style fallback.

## What changed

- Updated `CMakeLists.txt`:
  - detect `riscv64` / `riscv32` / `riscv` targets explicitly;
  - build `src/abpoa_align_simd.c` through the existing portable `SIMDE` path;
  - avoid falling through to the generic `-march=native` fallback branch;
  - define `__AVX2__` for RISC-V so the build uses the same AVX2-style `SIMDE` interface as the existing ARM portability path;
  - emit a configure-time status message for RISC-V targets.
- Updated `Makefile`:
  - when `ARCH` matches `riscv*`, use `-D__AVX2__` instead of `-march=native`;
  - keep the normal portable object set (`abpoa_align_simd.o`) rather than x86 runtime-dispatch objects.
- Updated `setup.py`:
  - when `uname -m` starts with `riscv`, define `__AVX2__` instead of using `-march=native`.
- Updated `README.md`:
  - document that current `riscv64` support uses the portable AVX2-style `SIMDE` path and does not provide a dedicated RVV backend.

## Verification

- Ran simulated `riscv64` CMake configure successfully:
  - `cmake -S . -B build-riscv-sim -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DABPOA_INSTALL=OFF`
- Confirmed the configure step prints:
  - `RISC-V target detected; building abPOA with the portable SIMDE path`
- Confirmed `build-riscv-sim/build.ninja`:
  - compiles `src/abpoa_align_simd.c` directly into the main library;
  - does not compile `abpoa_dispatch_simd.c`;
  - does not compile `abpoa_align_simd_sse2.c`, `abpoa_align_simd_sse41.c`, `abpoa_align_simd_avx2.c`, or `abpoa_align_simd_avx512bw.c`;
  - injects `-D__AVX2__` for the RISC-V build and still contains no `-march=native`, `-mavx*`, `-march=armv8*`, or `-mfpu=neon`.
- Ran a host-side single-variable probe with the Makefile RISC-V path:
  - `ARCH=riscv64 + USE_SIMDE + SIMDE_NO_NATIVE` without `__AVX2__` reproduces the real sample failure:
    - `[simd_abpoa_align_sequence_to_subgraph] Error in cg_backtrack.`
  - under the same workload, adding only `-D__AVX2__=1` makes `./test_data/seq.fa` complete successfully.
- Re-ran the Makefile RISC-V path after the patch without any manual extra `__AVX2__` override:
  - `make ARCH=riscv64 ... PREFIX=<tmp> abpoa`
  - the produced host binary completes `./test_data/seq.fa` successfully, showing that the patched RISC-V Makefile path now selects the working AVX2-style `SIMDE` configuration by default.
- Initialized the pinned `include/simde` submodule and compiled a forced-RISC-V wrapper against `src/simd_instruction.h`:
  - updated verification now expects the RISC-V path to keep `__AVX2__` defined rather than forcing it off.
- Compiled the public-header consumer in both default and forced-RISC-V modes:
  - `gcc -c -Wall -I./include ./tests/test_opaque_header.c -o ./build-riscv-sim/test_opaque_header.o`
  - `gcc -c -Wall -D__riscv=1 -D__riscv_xlen=64 -I./include ./tests/test_opaque_header.c -o ./build-riscv-sim/test_opaque_header_riscv.o`
- Performed a real `riscv64` cross build in `dockcross/linux-riscv64` by first cross-compiling a static `zlib` and then building `abpoa_bin` against that sysroot:
  - produced a real `riscv64` `abpoa` executable linked against the cross-built `libz.a`
  - `file`/`readelf -h` confirm it is a real RISC-V ELF executable
- Ran the sample workload under `qemu-riscv64`:
  - `qemu-riscv64 -L "$sysroot" <abpoa> /repo/test_data/seq.fa`
  - current result: completed successfully and printed the normal timing summary with no `cg_backtrack` error.

## Notes

- This is a conservative portability patch. It does not add RVV intrinsics or a RISC-V-specific runtime dispatch layer.
- The key behavioral change is not "enable AVX2 instructions on RISC-V"; it is "reuse the project's AVX2-shaped portable `SIMDE` interface on RISC-V", exactly as the existing ARM portability path already does.